### PR TITLE
Feat/fix connection endpoints task

### DIFF
--- a/Backend/backend/src/main/java/com/nocountry/backend/configuration/SecurityConfiguration.java
+++ b/Backend/backend/src/main/java/com/nocountry/backend/configuration/SecurityConfiguration.java
@@ -76,7 +76,7 @@ public class SecurityConfiguration {
         public CorsConfigurationSource corsConfigurationSource() {
                 CorsConfiguration configuration = new CorsConfiguration();
                 configuration.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
-                configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
                 configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
                 configuration.setAllowCredentials(true);
 

--- a/Backend/backend/src/main/java/com/nocountry/backend/mappers/CrmLeadMapper.java
+++ b/Backend/backend/src/main/java/com/nocountry/backend/mappers/CrmLeadMapper.java
@@ -5,30 +5,88 @@ import com.nocountry.backend.dto.CrmLeadDTO;
 import com.nocountry.backend.dto.UpdateCrmLeadDTO;
 import com.nocountry.backend.entity.CrmLead;
 import com.nocountry.backend.entity.Tag;
-import org.mapstruct.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Mapper(componentModel = "spring")
-public interface CrmLeadMapper {
+@Component
+@RequiredArgsConstructor
+public class CrmLeadMapper {
 
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "status", constant = "NEW")
-    @Mapping(target = "createdAt", ignore = true)
-    @Mapping(target = "updatedAt", ignore = true)
-    @Mapping(target = "tag", ignore = true)
-    CrmLead toEntity(CreateCrmLeadDTO dto);
+    private final AccountMapper accountMapper;
 
-    @Mapping(target = "tagIds", expression = "java(toTagIds(crmLead.getTag()))")
-    CrmLeadDTO toDTO(CrmLead crmLead);
+    public CrmLead toEntity(CreateCrmLeadDTO dto) {
+        if (dto == null) {
+            return null;
+        }
 
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    void updateCrmLeadFromDto(UpdateCrmLeadDTO dto, @MappingTarget CrmLead entity);
+        CrmLead crmLead = CrmLead.builder()
+                .name(dto.name())
+                .email(dto.email())
+                .phone(dto.phone())
+                .stage(dto.stage())
+                .channel(dto.channel())
+                .status("NEW")
+                .deleted(false)
+                .build();
 
-    // Tags → ids
-    default Set<Long> toTagIds(Set<Tag> tags) {
-        if (tags == null) return null;
-        return tags.stream().map(Tag::getId).collect(Collectors.toSet());
+        // Note: account, tags, createdAt, updatedAt should be set separately in the service
+        return crmLead;
+    }
+
+    public CrmLeadDTO toDTO(CrmLead crmLead) {
+        if (crmLead == null) {
+            return null;
+        }
+
+        // Mapear tags a IDs
+        Set<Long> tagIds = null;
+        if (crmLead.getTag() != null) {
+            tagIds = crmLead.getTag().stream()
+                    .map(Tag::getId)
+                    .collect(Collectors.toSet());
+        }
+
+        // Mapear account usando AccountMapper para evitar bucles
+        var accountDTO = accountMapper.toDTO(crmLead.getAccount());
+
+        return new CrmLeadDTO(
+                crmLead.getId(),
+                crmLead.getName(),
+                crmLead.getEmail(),
+                crmLead.getPhone(),
+                crmLead.getStage(),
+                crmLead.getChannel(),
+                crmLead.getStatus(),
+                crmLead.getCreatedAt(),
+                crmLead.getUpdatedAt(),
+                tagIds,
+                accountDTO
+        );
+    }
+
+    public void updateCrmLeadFromDto(UpdateCrmLeadDTO dto, CrmLead entity) {
+        if (dto == null || entity == null) {
+            return;
+        }
+
+        if (dto.name() != null) {
+            entity.setName(dto.name());
+        }
+        if (dto.email() != null) {
+            entity.setEmail(dto.email());
+        }
+        if (dto.phone() != null) {
+            entity.setPhone(dto.phone());
+        }
+        if (dto.stage() != null) {
+            entity.setStage(dto.stage());
+        }
+        if (dto.channel() != null) {
+            entity.setChannel(dto.channel());
+        }
+        // Note: status, account, and tags are handled separately in the service
     }
 }

--- a/frontend/components/tasks/EditTaskModal.tsx
+++ b/frontend/components/tasks/EditTaskModal.tsx
@@ -39,6 +39,7 @@ interface EditTaskModalProps {
     description?: string;
     dueDate: string;
     priority: Priority;
+    taskType: "MESSAGE" | "EMAIL";
     crmLead_Id: number;
   }) => void;
 }
@@ -122,11 +123,15 @@ export default function EditTaskModal({
       dueDateTime = `${formData.dueDate}T00:00:00`;
     }
 
+    // Use existing taskType from the task, or default to MESSAGE
+    const taskType = task.taskType || "MESSAGE";
+    
     onUpdateTask(task.id, {
       title: formData.title,
       description: formData.description,
       dueDate: dueDateTime,
       priority: formData.priority.toUpperCase() as Priority,
+      taskType: taskType as "MESSAGE" | "EMAIL",
       crmLead_Id: formData.contactId,
     });
 

--- a/frontend/services/task.service.ts
+++ b/frontend/services/task.service.ts
@@ -54,6 +54,7 @@ export interface TaskDTO {
   completed: boolean;
   createdAt: string; // ISO date string
   priority: Priority;
+  taskType: "MESSAGE" | "EMAIL"; // Backend enum
   crmLeadDTO: CrmLeadDTO;
   assignedTo: UserDTO;
 }
@@ -63,6 +64,7 @@ export interface CreateUpdateTaskDTO {
   description?: string;
   dueDate: string; // ISO date string
   priority: Priority;
+  taskType: "MESSAGE" | "EMAIL"; // Backend enum: MESSAGE or EMAIL
   crmLead_Id: number;
 }
 


### PR DESCRIPTION
1. Error 403 (Forbidden) al obtener tareas
Problema:
El frontend recibía 403 (Forbidden) al hacer GET /api/tasks.
El backend tenía errores de mapeo con MapStruct que impedían responder correctamente.
Causa raíz:
TaskMapper y CrmLeadMapper usaban MapStruct y creaban bucles al mapear relaciones:
Task → CrmLead → Account → User → Account (bucle infinito)
Task → User → Account → User (bucle infinito)

Solución:
Convertir TaskMapper de interfaz MapStruct a clase manual:
Usa UserMapper.toDTO() (devuelve UserDTO sin account)
Usa CrmLeadMapper.toDTO() para mapear el contacto
Convertir CrmLeadMapper de interfaz MapStruct a clase manual:
Usa AccountMapper.toDTO() para evitar bucles
Limpiar archivos generados por MapStruct con mvn clean para eliminar CrmLeadMapperImpl.java que causaba conflictos.
Archivos modificados:
Backend/backend/src/main/java/com/nocountry/backend/mappers/TaskMapper.java
Backend/backend/src/main/java/com/nocountry/backend/mappers/CrmLeadMapper.java


Frontend.
El backend requeria taskType, pero el frontend no lo envía. 
validación para manejar cuando crmLeadDTO es null o undefined: